### PR TITLE
feat: add product_id support in Firebase login — add to cart and redirect to checkout

### DIFF
--- a/4climbers-wordpress-express-integration.php
+++ b/4climbers-wordpress-express-integration.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: 4Climbers Wordpress-Express Integration
  * Description: Wordpress-Express integration for 4Climbers
- * Version: 1.16.0
+ * Version: 1.17.0
  * Author: Alessandro Defendenti (Rollercoders)
  */
 
@@ -478,7 +478,11 @@ function wc_notify_order($order_id)
 
 function wc_handle_firebase_login()
 {
-    if (!isset($_GET['firebase_login']) || !isset($_GET['token']) || !isset($_GET['page'])) {
+    if (!isset($_GET['firebase_login']) || !isset($_GET['token'])) {
+        return;
+    }
+
+    if (!isset($_GET['page']) && !isset($_GET['product_id'])) {
         return;
     }
 
@@ -494,7 +498,7 @@ function wc_handle_firebase_login()
         $verifiedIdToken = $auth->verifyIdToken($idTokenString);
         $email = $verifiedIdToken->claims()->get('email');
 
-        debug_log("wc_handle_firebase_login", "idTokenString: $idTokenString");
+        debug_log("wc_handle_firebase_login", "idTokenString: " . substr($idTokenString, 0, 20) . '...');
         debug_log("wc_handle_firebase_login", "email: $email");
 
         if (!$email) {
@@ -510,16 +514,46 @@ function wc_handle_firebase_login()
         wp_set_auth_cookie($user->ID, true);
         do_action('wp_login', $user->user_login, $user);
 
-        $page = $_GET['page'];
-
         // Forward ios_show_cookie_banner parameter if present
         $queryString = '';
         if (isset($_GET['ios_show_cookie_banner'])) {
             $queryString = '?ios_show_cookie_banner=' . sanitize_text_field($_GET['ios_show_cookie_banner']);
         }
 
+        if (isset($_GET['product_id'])) {
+            $product_id = absint($_GET['product_id']);
+
+            if ($product_id <= 0) {
+                wp_die('ID prodotto non valido');
+            }
+
+            $product = wc_get_product($product_id);
+
+            if (!$product || !$product->is_purchasable() || !$product->is_in_stock()) {
+                debug_log("wc_handle_firebase_login", "Prodotto non valido: $product_id");
+                wp_die('Prodotto non trovato o non acquistabile');
+            }
+
+            if (!function_exists('WC') || is_null(WC()->cart)) {
+                wp_die('Carrello WooCommerce non disponibile');
+            }
+
+            WC()->cart->empty_cart();
+            $result = WC()->cart->add_to_cart($product_id);
+
+            if (!$result) {
+                debug_log("wc_handle_firebase_login", "add_to_cart fallito per product_id: $product_id");
+                wp_die('Impossibile aggiungere il prodotto al carrello');
+            }
+
+            wp_safe_redirect(home_url('/checkout' . $queryString));
+            exit;
+        }
+
+        $page = sanitize_key($_GET['page']);
+
         if ($page !== 'checkout') {
-            wp_redirect(home_url("/$page" . $queryString));
+            wp_safe_redirect(home_url("/$page" . $queryString));
             exit;
         }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Code - Istruzioni di progetto
+
+## Git workflow
+
+- **Non committare mai direttamente su `develop` o `main`.**
+- Ogni feature/fix va su un branch dedicato (`feature/...`, `fix/...`).
+- Creare il branch **prima** di qualsiasi commit.
+- Aprire sempre una PR verso `develop`.
+
+## CI/CD
+
+- Il push su `develop` triggera una build e un deploy automatico.
+- I commit con messaggio che inizia con `chore:` non triggerano il deploy.

--- a/docs/superpowers/plans/2026-04-07-firebase-product-checkout.md
+++ b/docs/superpowers/plans/2026-04-07-firebase-product-checkout.md
@@ -1,0 +1,160 @@
+# Firebase Product Checkout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aggiungere supporto al parametro `product_id` nel flusso Firebase login, così che dopo il login il prodotto venga aggiunto al carrello (svuotato prima) e l'utente venga reindirizzato al checkout.
+
+**Architecture:** Modifica inline di `wc_handle_firebase_login` in `4climbers-wordpress-express-integration.php`. Si aggiorna anche la condizione di guard iniziale per accettare `product_id` come alternativa a `page`. La logica di redirect viene estesa con un branch dedicato al caso `product_id`.
+
+**Tech Stack:** PHP, WordPress, WooCommerce (`wc_get_product`, `WC()->cart`), Firebase (kreait/firebase-tokens).
+
+---
+
+## File Map
+
+- **Modify:** `4climbers-wordpress-express-integration.php`
+  - Funzione `wc_handle_firebase_login` (righe 479-532): guard iniziale + logica redirect
+
+---
+
+### Task 1: Aggiornare la guard iniziale per accettare `product_id`
+
+**Files:**
+- Modify: `4climbers-wordpress-express-integration.php:481`
+
+La condizione attuale richiede obbligatoriamente `page`. Con il nuovo parametro `product_id`, `page` non è più obbligatorio: è sufficiente avere `firebase_login` + `token` + (almeno uno tra `page` o `product_id`).
+
+- [ ] **Step 1: Modificare la condizione di guard in `wc_handle_firebase_login`**
+
+Sostituire righe 481-483:
+
+```php
+    if (!isset($_GET['firebase_login']) || !isset($_GET['token']) || !isset($_GET['page'])) {
+        return;
+    }
+```
+
+Con:
+
+```php
+    if (!isset($_GET['firebase_login']) || !isset($_GET['token'])) {
+        return;
+    }
+
+    if (!isset($_GET['page']) && !isset($_GET['product_id'])) {
+        return;
+    }
+```
+
+- [ ] **Step 2: Verificare manualmente che il comportamento esistente non sia rotto**
+
+Aprire il file e controllare che le righe 479-484 corrispondano esattamente al codice sopra.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add 4climbers-wordpress-express-integration.php
+git commit -m "fix: accept product_id as alternative to page in firebase login guard"
+```
+
+---
+
+### Task 2: Aggiungere la logica carrello e redirect al checkout
+
+**Files:**
+- Modify: `4climbers-wordpress-express-integration.php:513-527`
+
+Dopo il set della sessione WordPress (riga 511), aggiungere il branch `product_id` prima della logica `page` esistente.
+
+- [ ] **Step 1: Sostituire il blocco redirect (righe 513-527)**
+
+Sostituire:
+
+```php
+        $page = $_GET['page'];
+
+        // Forward ios_show_cookie_banner parameter if present
+        $queryString = '';
+        if (isset($_GET['ios_show_cookie_banner'])) {
+            $queryString = '?ios_show_cookie_banner=' . sanitize_text_field($_GET['ios_show_cookie_banner']);
+        }
+
+        if ($page !== 'checkout') {
+            wp_redirect(home_url("/$page" . $queryString));
+            exit;
+        }
+
+        wp_redirect(home_url('/premium' . $queryString));
+        exit;
+```
+
+Con:
+
+```php
+        // Forward ios_show_cookie_banner parameter if present
+        $queryString = '';
+        if (isset($_GET['ios_show_cookie_banner'])) {
+            $queryString = '?ios_show_cookie_banner=' . sanitize_text_field($_GET['ios_show_cookie_banner']);
+        }
+
+        if (isset($_GET['product_id'])) {
+            $product_id = absint($_GET['product_id']);
+
+            if ($product_id <= 0) {
+                wp_die('ID prodotto non valido');
+            }
+
+            $product = wc_get_product($product_id);
+
+            if (!$product || !$product->is_purchasable() || !$product->is_in_stock()) {
+                debug_log("wc_handle_firebase_login", "Prodotto non valido: $product_id");
+                wp_die('Prodotto non trovato o non acquistabile');
+            }
+
+            WC()->cart->empty_cart();
+            $result = WC()->cart->add_to_cart($product_id);
+
+            if (!$result) {
+                debug_log("wc_handle_firebase_login", "add_to_cart fallito per product_id: $product_id");
+                wp_die('Impossibile aggiungere il prodotto al carrello');
+            }
+
+            wp_redirect(home_url('/checkout' . $queryString));
+            exit;
+        }
+
+        $page = $_GET['page'];
+
+        if ($page !== 'checkout') {
+            wp_redirect(home_url("/$page" . $queryString));
+            exit;
+        }
+
+        wp_redirect(home_url('/premium' . $queryString));
+        exit;
+```
+
+- [ ] **Step 2: Verificare il file risultante**
+
+Aprire `4climbers-wordpress-express-integration.php` e controllare che:
+1. Il branch `product_id` appaia prima del branch `page`
+2. La variabile `$queryString` sia definita prima del branch `product_id`
+3. Il branch `page` esistente sia rimasto invariato sotto
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add 4climbers-wordpress-express-integration.php
+git commit -m "feat: add product_id support in firebase login — empty cart, add product, redirect to checkout"
+```
+
+---
+
+## Self-Review checklist
+
+- [x] Guard accetta `product_id` senza `page` ✓
+- [x] `$queryString` calcolato prima di entrambi i branch ✓
+- [x] Carrello svuotato prima di `add_to_cart` ✓
+- [x] Tutti i casi di errore coperti con `wp_die` + `debug_log` ✓
+- [x] Comportamento `page` esistente invariato ✓
+- [x] `ios_show_cookie_banner` propagato anche al redirect checkout ✓

--- a/docs/superpowers/specs/2026-04-07-firebase-product-checkout-design.md
+++ b/docs/superpowers/specs/2026-04-07-firebase-product-checkout-design.md
@@ -1,0 +1,104 @@
+# Design: Firebase Login con Product Checkout
+
+**Data:** 2026-04-07  
+**File coinvolto:** `4climbers-wordpress-express-integration.php`
+
+## Contesto
+
+Il flusso attuale permette di autenticare un utente tramite Firebase idToken e poi reindirizzarlo a una pagina WordPress. Il parametro `page=checkout` reindirizzava genericamente a `/premium`.
+
+Il cliente vuole ora poter passare l'ID di un prodotto specifico: dopo il login, quel prodotto viene aggiunto al carrello e l'utente viene mandato direttamente al checkout.
+
+## Nuovo URL
+
+```
+<base_url>?firebase_login=1&token=$idToken&product_id=123
+```
+
+Il parametro `page` rimane supportato per i redirect generici esistenti. `product_id` è il nuovo parametro dedicato.
+
+## Approccio scelto
+
+Modifica inline di `wc_handle_firebase_login` — aggiunta della logica carrello direttamente nella funzione esistente, dopo il set della sessione WordPress.
+
+## Flusso
+
+```
+URL: ?firebase_login=1&token=eyJ...&product_id=123
+        ↓
+  Valida idToken Firebase
+        ↓
+  Cerca utente per email in WordPress
+        ↓
+  Crea sessione + cookie persistente
+        ↓
+  product_id presente?
+    ├── NO  → comportamento attuale (redirect a /$page o /premium)
+    └── SI  →
+          Valida product_id (intero positivo)
+                ↓
+          wc_get_product() → purchasable + in stock?
+                ↓
+          WC()->cart->empty_cart()
+                ↓
+          WC()->cart->add_to_cart($product_id)
+                ↓
+          Redirect → /checkout
+```
+
+## Dettagli implementativi
+
+### Detection
+
+In `wc_maybe_hook_firebase_login`: nessun cambiamento, `product_id` non è richiesto per hookare.
+
+In `wc_handle_firebase_login`, dopo il login:
+- Se `product_id` è presente → gestisci checkout con prodotto
+- Altrimenti → comportamento attuale invariato
+
+### Logica carrello
+
+```php
+$product_id = absint($_GET['product_id']);
+
+if ($product_id <= 0) {
+    wp_die('ID prodotto non valido');
+}
+
+$product = wc_get_product($product_id);
+
+if (!$product || !$product->is_purchasable() || !$product->is_in_stock()) {
+    debug_log("wc_handle_firebase_login", "Prodotto non valido: $product_id");
+    wp_die('Prodotto non trovato o non acquistabile');
+}
+
+WC()->cart->empty_cart();
+$result = WC()->cart->add_to_cart($product_id);
+
+if (!$result) {
+    debug_log("wc_handle_firebase_login", "add_to_cart fallito per product_id: $product_id");
+    wp_die('Impossibile aggiungere il prodotto al carrello');
+}
+
+wp_redirect(home_url('/checkout' . $queryString));
+exit;
+```
+
+### Propagazione `ios_show_cookie_banner`
+
+Il parametro viene propagato anche nel redirect al checkout, coerentemente con il comportamento esistente.
+
+## Gestione errori
+
+| Caso | Comportamento |
+|------|---------------|
+| `product_id` non numerico o <= 0 | `wp_die('ID prodotto non valido')` |
+| Prodotto non trovato | `wp_die('Prodotto non trovato o non acquistabile')` + log |
+| Prodotto non purchasable o fuori stock | `wp_die('Prodotto non trovato o non acquistabile')` + log |
+| `add_to_cart()` ritorna `false` | `wp_die('Impossibile aggiungere il prodotto al carrello')` + log |
+
+## Retrocompatibilità
+
+- URL senza `product_id` → comportamento invariato
+- `page=checkout` → continua a redirectare a `/premium`
+- Tutti gli altri valori di `page` → redirect a `/$page`


### PR DESCRIPTION
## Summary

- Aggiunto supporto al parametro `product_id` nel flusso di login Firebase
- Dopo il login, il prodotto specificato viene aggiunto al carrello (svuotato prima) e l'utente viene reindirizzato a `/checkout`
- Flusso `page` esistente retrocompatibile e invariato

## Nuovo URL

```
<base_url>?firebase_login=1&token=$idToken&product_id=123
```

## Modifiche principali

- Guard iniziale aggiornata: `product_id` accettato come alternativa a `page`
- Branch `product_id`: validazione prodotto, svuotamento carrello, `add_to_cart`, redirect a `/checkout`
- Guard su `WC()->cart` prima dell'uso
- `wp_safe_redirect` usato per tutti i redirect
- `$page` sanitizzato con `sanitize_key()`
- Log token JWT troncato ai primi 20 caratteri

## Test plan

- [ ] Login con `?firebase_login=1&token=...&product_id=<ID_VALIDO>` → carrello svuotato, prodotto aggiunto, redirect a `/checkout`
- [ ] Login con `product_id` di prodotto inesistente → `wp_die` con messaggio di errore
- [ ] Login con `product_id` di prodotto fuori stock / non acquistabile → `wp_die`
- [ ] Login con `?page=premium` (senza `product_id`) → comportamento invariato, redirect a `/premium`
- [ ] Login con `?page=checkout` (senza `product_id`) → redirect a `/premium` come prima
- [ ] Login con `?product_id=123&ios_show_cookie_banner=0` → parametro propagato al redirect checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)